### PR TITLE
Allow constants initialization

### DIFF
--- a/crystal_sample/lib.cr
+++ b/crystal_sample/lib.cr
@@ -1,8 +1,9 @@
-
-fun lib_init() : Void
+fun lib_init : Void
   GC.init
+  argv = ["fake-program_name".to_unsafe].to_unsafe
+  LibCrystalMain.__crystal_main(1, argv)
 end
 
-fun lib_hello() : Void
+fun lib_hello : Void
   puts "Hello from Crystal"
 end


### PR DESCRIPTION
In Crystal 0.31 the constant initialization changed quite a bit.

The PROGRAM_NAME assumes there is at least one ARGV, hence the forced fake-program_name. An empty string would also work.